### PR TITLE
Styled Text Markdown Parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
       <version>0.4</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.markdownj</groupId>
+      <artifactId>markdownj-core</artifactId>
+      <version>0.4</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -149,10 +149,14 @@ public class ChatServlet extends HttpServlet {
      */
     MarkdownProcessor mark_it = new MarkdownProcessor();
     String parsedMessageContent = mark_it.markdown(cleanedMessageContent);
-    // Remove <p> and </p> that markdown processor adds to string
+    /* Sample Markdown Processor demo:
+     * enter "**important** markdown `monospace` _italic_"
+     * returns "<p><strong>important</strong> markdown <code>monospace</code> <em>italic</em></p>\n"
+     * remove <p> to get "<strong>important</strong> markdown <code>monospace</code> <em>italic</em>"
+     */
+    // Remove <p> and </p>\n that markdown processor adds to string
     int i = parsedMessageContent.length();
-    /* deleted 5th character from the end b/c markdown processor
-     * apparently adds an extra <
+    /* deleted 5th character from the end
      */
     parsedMessageContent = new
             StringBuilder(parsedMessageContent).delete(i-5, i).toString();

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -143,10 +143,15 @@ public class ChatServlet extends HttpServlet {
 
     // this removes any HTML from the message content
     String cleanedMessageContent = Jsoup.clean(messageContent, Whitelist.none());
+    String parsedMessageContent = cleanedMessageContent;
 
-    // use MarkdownProcessor to parse any markdown
-    MarkdownProcessor mark_it = new MarkdownProcessor();
-    String parsedMessageContent = mark_it.markdown(cleanedMessageContent);
+    /* use MarkdownProcessor to parse any markdown if the message
+     * contains markdown
+     */
+    if (cleanedMessageContent.contains("**")) {
+        MarkdownProcessor mark_it = new MarkdownProcessor();
+        parsedMessageContent = mark_it.markdown(cleanedMessageContent);
+    }
 
 
     Message message =

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -151,8 +151,13 @@ public class ChatServlet extends HttpServlet {
     if (cleanedMessageContent.contains("**")) {
         MarkdownProcessor mark_it = new MarkdownProcessor();
         parsedMessageContent = mark_it.markdown(cleanedMessageContent);
+        // Remove <p> and </p> that markdown processor adds to string
+        parsedMessageContent = new
+                StringBuilder(parsedMessageContent).delete(0,2).toString();
+        int i = parsedMessageContent.length() - 1;
+        parsedMessageContent = new
+                StringBuilder(parsedMessageContent).delete(i-3, i).toString();
     }
-
 
     Message message =
         new Message(

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -143,25 +143,21 @@ public class ChatServlet extends HttpServlet {
 
     // this removes any HTML from the message content
     String cleanedMessageContent = Jsoup.clean(messageContent, Whitelist.none());
-    String parsedMessageContent = cleanedMessageContent;
 
     /* use MarkdownProcessor to parse any markdown if the message
      * contains markdown
      */
-    if (cleanedMessageContent.contains("**")) {
-        MarkdownProcessor mark_it = new MarkdownProcessor();
-        parsedMessageContent = mark_it.markdown(cleanedMessageContent);
-        // Remove <p> and </p> that markdown processor adds to string
-        int i = parsedMessageContent.length();
-        /* deleted 5th character from the end b/c markdown processor
-         * apparently adds an extra <
-         */
-        parsedMessageContent = new
-              StringBuilder(parsedMessageContent).delete(i-5, i).toString();
-        parsedMessageContent = new
-                StringBuilder(parsedMessageContent).delete(0,3).toString();
-    }
-
+    MarkdownProcessor mark_it = new MarkdownProcessor();
+    String parsedMessageContent = mark_it.markdown(cleanedMessageContent);
+    // Remove <p> and </p> that markdown processor adds to string
+    int i = parsedMessageContent.length();
+    /* deleted 5th character from the end b/c markdown processor
+     * apparently adds an extra <
+     */
+    parsedMessageContent = new
+            StringBuilder(parsedMessageContent).delete(i-5, i).toString();
+    parsedMessageContent = new
+            StringBuilder(parsedMessageContent).delete(0,3).toString();
     Message message =
         new Message(
             UUID.randomUUID(),

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
+import org.markdownj.MarkdownProcessor;
 
 /** Servlet class responsible for the chat page. */
 public class ChatServlet extends HttpServlet {
@@ -143,12 +144,17 @@ public class ChatServlet extends HttpServlet {
     // this removes any HTML from the message content
     String cleanedMessageContent = Jsoup.clean(messageContent, Whitelist.none());
 
+    // use MarkdownProcessor to parse any markdown
+    MarkdownProcessor mark_it = new MarkdownProcessor();
+    String parsedMessageContent = mark_it.markdown(cleanedMessageContent);
+
+
     Message message =
         new Message(
             UUID.randomUUID(),
             conversation.getId(),
             user.getId(),
-            cleanedMessageContent,
+            parsedMessageContent,
             Instant.now());
 
     messageStore.addMessage(message);

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -152,11 +152,14 @@ public class ChatServlet extends HttpServlet {
         MarkdownProcessor mark_it = new MarkdownProcessor();
         parsedMessageContent = mark_it.markdown(cleanedMessageContent);
         // Remove <p> and </p> that markdown processor adds to string
+        int i = parsedMessageContent.length();
+        /* deleted 5th character from the end b/c markdown processor
+         * apparently adds an extra <
+         */
         parsedMessageContent = new
-                StringBuilder(parsedMessageContent).delete(0,2).toString();
-        int i = parsedMessageContent.length() - 1;
+              StringBuilder(parsedMessageContent).delete(i-5, i).toString();
         parsedMessageContent = new
-                StringBuilder(parsedMessageContent).delete(i-3, i).toString();
+                StringBuilder(parsedMessageContent).delete(0,3).toString();
     }
 
     Message message =
@@ -173,3 +176,4 @@ public class ChatServlet extends HttpServlet {
     response.sendRedirect("/chat/" + conversationTitle);
   }
 }
+

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -196,4 +196,31 @@ public class ChatServletTest {
 
     Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
   }
+
+  @Test
+  public void testDoPost_ParseMarkdown() throws IOException, ServletException {
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
+
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now());
+    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
+
+    Conversation fakeConversation =
+            new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+    Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
+            .thenReturn(fakeConversation);
+
+    Mockito.when(mockRequest.getParameter("message"))
+            .thenReturn("Contains **important** markdown content _italic_");
+
+    chatServlet.doPost(mockRequest, mockResponse);
+
+    ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
+    Mockito.verify(mockMessageStore).addMessage(messageArgumentCaptor.capture());
+    Assert.assertEquals(
+            "Contains <strong>important</strong> markdown content <em>italic</em>",
+            messageArgumentCaptor.getValue().getContent());
+
+    Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
+  }
 }

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -223,4 +223,31 @@ public class ChatServletTest {
 
     Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
   }
+
+  @Test
+  public void testDoPost_PartialMarkdown() throws IOException, ServletException {
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
+
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now());
+    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
+
+    Conversation fakeConversation =
+            new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+    Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
+            .thenReturn(fakeConversation);
+
+    Mockito.when(mockRequest.getParameter("message"))
+            .thenReturn("**important** _italic_ _markdown half bold**");
+
+    chatServlet.doPost(mockRequest, mockResponse);
+
+    ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
+    Mockito.verify(mockMessageStore).addMessage(messageArgumentCaptor.capture());
+    Assert.assertEquals(
+            "<strong>important</strong> <em>italic</em> _markdown half bold**",
+            messageArgumentCaptor.getValue().getContent());
+
+    Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
+  }
 }

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -211,14 +211,14 @@ public class ChatServletTest {
             .thenReturn(fakeConversation);
 
     Mockito.when(mockRequest.getParameter("message"))
-            .thenReturn("Contains **important** markdown content _italic_");
+            .thenReturn("**important** markdown `monospace` _italic_");
 
     chatServlet.doPost(mockRequest, mockResponse);
 
     ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
     Mockito.verify(mockMessageStore).addMessage(messageArgumentCaptor.capture());
     Assert.assertEquals(
-            "Contains <strong>important</strong> markdown content <em>italic</em>",
+            "<strong>important</strong> markdown <code>monospace</code> <em>italic</em>",
             messageArgumentCaptor.getValue().getContent());
 
     Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");


### PR DESCRIPTION
In order to enable the user to enter markdown, I used the MarkdownJ library (https://github.com/myabc/markdownj) and added that as a dependency into the pom.xml file like we did with BCrypt. Now, for any message, I parse it with the Markdown Parser and manually remove the <p> headers that it attaches. I implemented this in ChatServlet and added 2 tests in ChatServletTest to make sure it parses markdown in the way one expects it to. 